### PR TITLE
Bumped to 1.0.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+1.0.4
+=====
+* Added support for Python 3.6, 3.7 and 3.8
+* Made ``path`` a getter so that the return type is non-None
+
 1.0.3
 =====
 * Added py.typed to the distribution so that the library can be used with mypy

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='temppathlib',
-    version='1.0.3',
+    version='1.0.4',  # don't forget to update the changelog!
     description='Wrap tempfile to give you pathlib.Path.',
     long_description=long_description,
     url='https://github.com/Parquery/temppathlib',


### PR DESCRIPTION
* Added support for Python 3.6, 3.7 and 3.8
* Made ``path`` a getter so that the return type is non-None