### PR TITLE
Wrapped `tempfile.gettempdir`

### DIFF
--- a/temppathlib/__init__.py
+++ b/temppathlib/__init__.py
@@ -241,3 +241,13 @@ class NamedTemporaryFile:
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:  # type: ignore
         """Close the temporary file."""
         self.close()
+
+
+def gettempdir() -> pathlib.Path:
+    """
+    Wrap ``tempfile.gettempdir``.
+
+    Please see the documentation of ``tempfile.gettempdir`` for more details:
+    https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir
+    """
+    return pathlib.Path(tempfile.gettempdir())

--- a/tests/test_temppathlib.py
+++ b/tests/test_temppathlib.py
@@ -135,5 +135,13 @@ class TestNamedTemporaryFile(unittest.TestCase):
                 self.assertTrue(tmp.path.exists())
 
 
+class TestGettempdir(unittest.TestCase):
+    def test_that_it_works(self) -> None:
+        tmpdir = temppathlib.gettempdir()
+
+        original_tmpdir = tempfile.gettempdir()
+        self.assertEqual(original_tmpdir, str(tmpdir))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This patch adds a very thin wrapper for `tempfile.gettempdir`.