### PR TITLE
Revisited the supported Python versions up to 3.10

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/check-push.yml
+++ b/.github/workflows/check-push.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@master

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,11 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         # yapf: enable
     ],
     keywords='tempfile pathlib temporary file directory mkdtemp mkstemp',
@@ -40,8 +41,8 @@ setup(
     extras_require={
         'dev': [
             # yapf: disable
-            'mypy==0.790',
-            'pylint==2.6.0',
+            'mypy==0.941',
+            'pylint==2.12.2',
             'yapf==0.20.2',
             'tox>=3,<4',
             'coverage>=5,<6',

--- a/temppathlib/__init__.py
+++ b/temppathlib/__init__.py
@@ -16,7 +16,7 @@ class removing_tree:  # pylint: disable=invalid-name
         elif isinstance(path, pathlib.Path):
             self.path = path
         else:
-            raise ValueError("Unexpected type of 'path': {}".format(type(path)))
+            raise ValueError(f"Unexpected type of 'path': {type(path)}")
 
     def __enter__(self) -> pathlib.Path:
         """Give back the path that will be removed."""
@@ -75,7 +75,7 @@ class TmpDirIfNecessary:
         elif isinstance(base_tmp_dir, str):
             self.base_tmp_dir = pathlib.Path(base_tmp_dir)
         else:
-            raise ValueError("Unexpected type of 'base_tmp_dir': {}".format(type(base_tmp_dir)))
+            raise ValueError(f"Unexpected type of 'base_tmp_dir': {type(base_tmp_dir)}")
 
         self._path = None  # type: Optional[pathlib.Path]
 
@@ -86,7 +86,7 @@ class TmpDirIfNecessary:
         elif isinstance(path, pathlib.Path):
             self._path = path
         else:
-            raise ValueError("Unexpected type for the argument `path`: {}".format(type(path)))
+            raise ValueError(f"Unexpected type for the argument `path`: {type(path)}")
 
         self.dont_delete = dont_delete_tmp_dir
 
@@ -102,7 +102,7 @@ class TmpDirIfNecessary:
         """Get the underlying path or raise if the path has not been set."""
         if self._path is None:
             raise RuntimeError("The _path has not been set. "
-                               "Are you using {} outside of the context management?".format(self.__class__.__name__))
+                               f"Are you using {self.__class__.__name__} outside of the context management?")
 
         return self._path
 
@@ -156,7 +156,7 @@ class TemporaryDirectory:
         elif isinstance(base_tmp_dir, str):
             self.base_tmp_dir = pathlib.Path(base_tmp_dir)
         else:
-            raise ValueError("Unexpected type of 'base_tmp_dir': {}".format(type(base_tmp_dir)))
+            raise ValueError(f"Unexpected type of 'base_tmp_dir': {type(base_tmp_dir)}")
 
         self.prefix = prefix
         self.dont_delete = dont_delete
@@ -176,7 +176,7 @@ class TemporaryDirectory:
         """Get the underlying path or raise if the path has not been set."""
         if self._path is None:
             raise RuntimeError("The _path has not been set. "
-                               "Are you using {} outside of the context management?".format(self.__class__.__name__))
+                               f"Are you using {self.__class__.__name__} outside of the context management?")
 
         return self._path
 
@@ -231,6 +231,7 @@ class NamedTemporaryFile:
 
         :param delete: whether the file is deleted on close (default True).
         """
+        # pylint: disable=consider-using-with
         self.__tmpfile = tempfile.NamedTemporaryFile(
             mode=mode,
             buffering=buffering,
@@ -243,7 +244,7 @@ class NamedTemporaryFile:
 
         self.path = pathlib.Path(self.__tmpfile.name)
 
-        file = self.__tmpfile.file  # type: ignore
+        file = self.__tmpfile.file
         self.file = file  # type: IO[Any]
         self.delete = delete
 

--- a/tests/test_temppathlib.py
+++ b/tests/test_temppathlib.py
@@ -24,7 +24,7 @@ class TestRemovingTree(unittest.TestCase):
                 self.assertTrue(pth.exists())
 
                 subpth = pth / 'oi.txt'
-                with subpth.open('wt') as fid:
+                with subpth.open('wt', encoding='utf-8') as fid:
                     fid.write('hey!')
                     fid.flush()
 
@@ -45,20 +45,20 @@ class TestRemovingTree(unittest.TestCase):
             dir2 = tmp_dir / "dir2"
             dir2.mkdir()
 
-            names = sorted(list([pth.name for pth in tmp_dir.iterdir()]))
+            names = sorted(pth.name for pth in tmp_dir.iterdir())
             self.assertListEqual(names, ['dir1', 'dir2'])
 
             # context manager invoked without enter does not delete the path.
             temppathlib.removing_tree(path=dir1)
 
-            names = sorted(list([pth.name for pth in tmp_dir.iterdir()]))
+            names = sorted(pth.name for pth in tmp_dir.iterdir())
             self.assertListEqual(names, ['dir1', 'dir2'])
 
             # context manager invoked with enter does delete the path.
             with temppathlib.removing_tree(path=dir1):
                 pass
 
-            names = sorted(list([pth.name for pth in tmp_dir.iterdir()]))
+            names = sorted(pth.name for pth in tmp_dir.iterdir())
             self.assertListEqual(names, ['dir2'])
         finally:
             if tmp_dir.exists():


### PR DESCRIPTION
We dropped the checks for Python 3.5 and added checks for 3.9 and 3.10,
respectively, in the continuous integration.

Python 3.5 reached the end-of-life already some time ago.