### PR TITLE
Bumped to 1.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
+1.2.0
+=====
+* Revisited the supported Python versions up to 3.10 (#13)
+* Supported prefix and suffix in ``TmpDirIfNecessary`` (#12)
+
 1.1.0
 =====
-* Wrapped `tempfile.gettempdir` (#7)
+* Wrapped ``tempfile.gettempdir`` (#7)
 
 1.0.4
 =====

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='temppathlib',
-    version='1.1.0',  # don't forget to update the changelog!
+    version='1.2.0',  # don't forget to update the changelog!
     description='Wrap tempfile to give you pathlib.Path.',
     long_description=long_description,
     url='https://github.com/Parquery/temppathlib',


### PR DESCRIPTION
* Revisited the supported Python versions up to 3.10 (#13)
* Supported prefix and suffix in ``TmpDirIfNecessary`` (#12)